### PR TITLE
Use doubleplus-numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,18 @@ assert.deepEqual(
       path: [ 'content', 0, 'form', 'content', 0 ],
       source: 'commonform-critique',
       url: null } ])
+
+assert.deepEqual(
+  critique({ content: [ 'Give me two (2) of those and four (4) of the other one.' ] }),
+  [ { message: '"two (2)" repeats a written number and numeral, which is redundant and error-prone',
+      level: "info",
+      path: [ 'content', 0 ],
+      source: 'doubleplus-numbers',
+      url: null },
+    { message: '"four (4)" repeats a written number and numeral, which is redundant and error-prone',
+      level: "info",
+      path: [ 'content', 0 ],
+      source: 'doubleplus-numbers',
+      url: null } ])
+
 ```

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var archaic = require('commonform-archaic')
+var doubleplus = require('doubleplus-numbers')
 var mscd = require('commonform-mscd')
 var predicate = require('commonform-predicate')
 
@@ -31,6 +32,7 @@ module.exports = function(form) {
   return [ ]
     .concat(archaic(form))
     .concat(mscd(form))
+    .concat(doubleplus(form))
     .concat(
       recurse(form, [ ], [ ])
         .map(function(annotation) {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "commonform-archaic": "^1.1.0",
     "commonform-mscd": "^0.1.0",
     "commonform-predicate": "^0.4.0",
+    "doubleplus-numbers": "^0.1.0",
     "wordy-words": "^0.0.11"
   },
   "devDependencies": {


### PR DESCRIPTION
I cherry-picked the test you added to README and added doubleplus-numbers in to pass it.

Related: commonform/commonform-critique#2

If you'd like to hard-reset your `master` onto something like this, I'll be happy to close out your earlier PR.

Thanks again!
